### PR TITLE
Simplify project setup by removing global grunt-cli dependency [minor]

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,12 @@ If your company meets the above requirements and you'd like to be added to the l
 
 Getting started:
  - [Download and install Node.js](http://nodejs.org/) if you haven't already
- - Install Grunt command line tools with `npm install -g grunt-cli`
  - Clone this repo with `git clone https://github.com/sampl/madeina2.git` and `cd madeina2`
  - Run `npm install`. *Note: if `npm install` fails, try `sudo npm install` or do [this](http://stackoverflow.com/questions/16151018/npm-throws-error-without-sudo).*
 
-Run `grunt` to build the site and start a webserver at [localhost:8000](http://localhost:8000/). Install LiveReload to automatically refresh the page when you've made changes.
+Run `npm start` to build the site and start a webserver at [localhost:8000](http://localhost:8000/). Install LiveReload to automatically refresh the page when you've made changes.
 
-To deploy, first ensure that you're a collaborator on the github repo, then run `grunt deploy`.
+To deploy, first ensure that you're a collaborator on the github repo, then run `npm run deploy`.
 
 
 ### Slack team invitations

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,11 +40,27 @@
       "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
       "dev": true
     },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
     "batch": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz",
       "integrity": "sha1-/S4Fp6XWlrTbkxQBPihdj/NVfsM=",
       "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "buffer-crc32": {
       "version": "0.2.1",
@@ -95,6 +111,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz",
       "integrity": "sha1-0bhvkB+LZL2UG96tr5JFMDk76Sg=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "connect": {
@@ -348,6 +370,60 @@
         "which": "1.0.9"
       }
     },
+    "grunt-cli": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
+      "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
+      "dev": true,
+      "requires": {
+        "findup-sync": "0.3.0",
+        "grunt-known-options": "1.1.0",
+        "nopt": "3.0.6",
+        "resolve": "1.1.7"
+      },
+      "dependencies": {
+        "findup-sync": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+          "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+          "dev": true,
+          "requires": {
+            "glob": "5.0.15"
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.1.0"
+          }
+        }
+      }
+    },
     "grunt-contrib-clean": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.5.0.tgz",
@@ -431,6 +507,12 @@
           "dev": true
         }
       }
+    },
+    "grunt-known-options": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz",
+      "integrity": "sha1-pCdO6zL6dl2lp6OxcSYXzjsUQUk=",
+      "dev": true
     },
     "grunt-legacy-log": {
       "version": "0.1.3",
@@ -532,6 +614,16 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
       "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
       "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -723,6 +815,15 @@
         }
       }
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
     "open": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/open/-/open-0.0.4.tgz",
@@ -742,6 +843,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package/-/package-1.0.1.tgz",
       "integrity": "sha1-0lofmeJQbcsn1nBLg9yooxLk7cw=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "pause": {
@@ -828,6 +935,12 @@
       "requires": {
         "minimatch": "0.2.14"
       }
+    },
+    "resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
     },
     "rimraf": {
       "version": "2.2.8",
@@ -1054,6 +1167,12 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
       "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "wrench": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "devDependencies": {
     "grunt": "~0.4.2",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-connect": "~0.6.0",
     "grunt-contrib-copy": "~0.5.0",
@@ -10,5 +11,9 @@
     "grunt-contrib-watch": "~0.5.3",
     "grunt-gh-pages": "^1.1.0",
     "grunt-s3": "~0.2.0-alpha.3"
+  },
+  "scripts": {
+    "start": "grunt",
+    "deploy": "grunt deploy"
   }
 }


### PR DESCRIPTION
This is a very minor project setup change.

With this change, we funnel all development and deployment tasks through npm scripts. This has the advantages of…

_1. Simpler setup_

In the README, we are removing one step from the setup process, and that is requiring users to install a global dependency: `npm install -g grunt-cli` Now, as long as they have node, they just need to clone the repository, go into the directory, and run `npm install`.

_2. Abstract development & deployment tasks through npm scripts_

The project's CLI now goes totally through npm scripts:

`npm start` == get a development environment going
`npm run deploy` == push a product deployment

These two commands can remain constant even if the project were to change from using grunt to some other assets compilation tool.