### PR TITLE
feat(auto-deployment): add site deployment via GitHub Actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,27 @@
+# This is a basic workflow for deploying the site
+
+name: github pages
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+    # Sets up the proper node version
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+
+    - run: npm install
+    - run: npm run build
+
+    - uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./build

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -69,6 +69,10 @@ module.exports = (grunt) ->
 	# run this task with "grunt"
 	grunt.registerTask('default', ['clean', 'copy', 'jade', 'connect', 'watch'])
 
+	# compiles the site
+	# run this task with "grunt build"
+	grunt.registerTask('build', ['clean', 'copy', 'jade'])
+
 	# compiles the site and sends it to Amazon S3 (see readme for directions)
 	# run this task with "grunt deploy"
-	grunt.registerTask('deploy', ['clean', 'copy', 'jade', 'gh-pages'])
+	grunt.registerTask('deploy', ['build', 'gh-pages'])

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "start": "grunt",
+    "build": "grunt build",
     "deploy": "grunt deploy"
   }
 }


### PR DESCRIPTION
## 1. Overview

This replaces the manual site deployment process (running `npn run deploy`) with a [GitHub Action][ga] that will automatically publish the `gh-pages` branch with changes for public release on every push to `origin/master`.

The change involves (1) making a dedicated build task to compile the site, and then (b) taking that build output and deploying it to the `origin/gh-pages` branch via [a community action][ca].

[ca]: https://github.com/peaceiris/actions-gh-pages
[ga]: https://github.com/features/actions

## 2. How to Test

There’s no automated test coverage. I manually [tweaked the branch that the action targets][ba] and watched a [successful action run to deploy the site with a test change][ta].

[ta]: https://github.com/MadeInA2/madeina2/actions/runs/220858087
[ba]: https://github.com/MadeInA2/madeina2/blob/697223057fe5d3e7edde8b6d392968ae094dc2a3/.github/workflows/gh-pages.yml#L7

## 3. Related Issues

1. Resolves https://github.com/MadeInA2/madeina2/issues/122

---

## 4. Appendix: Fun with GitHub Codespaces

This was the first change I’ve ever made using [GitHub Codespaces][ghc], and it was pretty neat! 😀 

<img src="https://user-images.githubusercontent.com/14554/90983550-0487dd00-e53d-11ea-841f-5a4268faf638.jpeg" width="300" />

## 5. Appendix: Related Resources

1. [A site tech rewrite in the form of a Single-Page Application (SPA)](https://github.com/MadeInA2/madeina2/pull/123). This work could still use automated deployments.

[ghc]: https://github.com/features/codespaces