### PR TITLE
Update Slack link

### DIFF
--- a/source/pages/slack/index.jade
+++ b/source/pages/slack/index.jade
@@ -1,2 +1,2 @@
 script.
-	window.location.replace("http://madeina2slackin.herokuapp.com/")
+	window.location.replace("https://join.slack.com/t/madeina2/shared_invite/zt-2ei90ufer-FibdE9emv5Y1ddwehPu5OQ")


### PR DESCRIPTION
The current link seems to point to a now-defunct Heroku app. I found this invite URL through [another site](https://annarborusa.org/why-ann-arbor/business-culture/) and it seems to be active, so I figure this is a better option.

Let me know if you prefer to solve this differently though!